### PR TITLE
chore: remove @efiop from maintainers

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -45,4 +45,3 @@ about:
 extra:
   recipe-maintainers:
     - shcheklein
-    - efiop


### PR DESCRIPTION
Remove `efiop` from the `grandalf` feedstock maintainer list because I am stepping away from conda-forge maintenance.

This leaves `shcheklein` as the remaining recipe maintainer. There is no package or build change.

Validation: `git diff --check`.
